### PR TITLE
改进自动多模块在默认应用目录不存在时跳过设定默认应用问题

### DIFF
--- a/src/MultiApp.php
+++ b/src/MultiApp.php
@@ -135,11 +135,15 @@ class MultiApp
                     $appName = $map['*'];
                 } else {
                     $appName = $name;
+                    $defaultAppName = $this->app->config->get('app.default_app', 'index');
+                    if("" === $appName){
+                        $appName =  $defaultAppName;
+                    }
                     $appPath = $this->path ?: $this->app->getBasePath() . $appName . DIRECTORY_SEPARATOR;
                     if (!is_dir($appPath)) {
                         $express = $this->app->config->get('app.app_express', false);
                         if ($express) {
-                            $this->setApp($this->app->config->get('app.default_app', 'index'));
+                            $this->setApp($defaultAppName);
                             return true;
                         } else {
                             return false;


### PR DESCRIPTION
主要表现为 引入该模块后未建立默认应用 如 index 应用 会报错 控制器不存在:app\index\controller\Index 此时可转为单应用模式访问 app/controller/Index