### PR TITLE
修复当降为单应用模式时url会生成两个分隔符

### DIFF
--- a/src/Url.php
+++ b/src/Url.php
@@ -180,7 +180,7 @@ class Url extends UrlBuild
             $file = str_replace('\\', '/', dirname($file));
         }
 
-        $url = rtrim($file, '/') . '/' . $url;
+        $url = rtrim($file, '/') . '/' . ltrim($url, '/');
 
         // URL后缀
         if ('/' == substr($url, -1) || '' == $url) {


### PR DESCRIPTION
自动切换到单应用模式时，在控制器里生成的url会生成两个分隔符, `url('test')->build()` 将生成 `/index.php//Index/test.html` 。