### PR TITLE
修复多应用模式绑定域名不能正确识别当前域名的bug

### DIFF
--- a/src/Url.php
+++ b/src/Url.php
@@ -59,6 +59,7 @@ class Url extends UrlBuild
             $bind = $this->app->config->get('app.domain_bind', []);
 
             if ($key = array_search($app, $bind)) {
+                isset($bind[$_SERVER['SERVER_NAME']]) && $domain = $_SERVER['SERVER_NAME'];
                 $domain = is_bool($domain) ? $key : $domain;
             } else {
                 $map = $this->app->config->get('app.app_map', []);


### PR DESCRIPTION
在多应用配置文件中，使用两个域名绑定同一个应用，再使用`url('index/index')->build()`等方法时，会出现不能正确识别当前域名的问题。
示例配置：
```
'domain_bind' => [
  'a.home.dk' => 'index',
  'b.home.dk' => 'index'
]
```
bug举例：
在访问`b.home.dk`时使用`url('index/index')->build()`，会返回`a.home.dk/index/index`。