### PR TITLE
pathinfo分隔符 从配置文件中取值

### DIFF
--- a/src/MultiApp.php
+++ b/src/MultiApp.php
@@ -123,7 +123,8 @@ class MultiApp
                 $path = $this->app->request->pathinfo();
                 $map  = $this->app->config->get('app.app_map', []);
                 $deny = $this->app->config->get('app.deny_app_list', []);
-                $name = current(explode('/', $path));
+                $pathinfo_depr= $this->app->config->get('route.pathinfo_depr', '/'); //pathinfo 从配置文件中取值
+                $name = current(explode($pathinfo_depr, $path));
 
                 if (strpos($name, '.')) {
                     $name = strstr($name, '.', true);


### PR DESCRIPTION
修复pathinfo分隔符写死为‘/’的瑕疵，希望能够得到合并