### PR TITLE
入口文件已绑定应用时，生成的URL地址不携带应用名

### DIFF
--- a/src/Url.php
+++ b/src/Url.php
@@ -42,15 +42,17 @@ class Url extends UrlBuild
             // 解析到控制器
             $url = substr($url, 1);
         } elseif ('' === $url) {
-            $url = $this->getAppName() . '/' . $request->controller() . '/' . $request->action();
+            $url = $request->controller() . '/' . $request->action();
+            if (!$this->app->http->isBind()) {
+                $url = $this->getAppName() . '/' . $url;
+            }
         } else {
             // 解析到 应用/控制器/操作
             $controller = $request->controller();
-            $app        = $this->getAppName();
             $path       = explode('/', $url);
             $action     = array_pop($path);
             $controller = empty($path) ? $controller : array_pop($path);
-            $app        = empty($path) ? $app : array_pop($path);
+            $app        = empty($path) ? $this->getAppName() : array_pop($path);
             $url        = $controller . '/' . $action;
             $bind       = $this->app->config->get('app.domain_bind', []);
 
@@ -58,7 +60,7 @@ class Url extends UrlBuild
                 isset($bind[$_SERVER['SERVER_NAME']]) && $domain = $_SERVER['SERVER_NAME'];
 
                 $domain = is_bool($domain) ? $key : $domain;
-            } else {
+            } elseif (!$this->app->http->isBind()) {
                 $url = $app . '/' . $url;
             }
         }


### PR DESCRIPTION
更新到`(dev-master ccaad7c)`后，测试问题依然存在，所以提交了此PR。
----
访问网址：`http://think.com/admin.php/Index/index.html`
生成代码：`url('Index/profile')`
生成网址：`http://think.com/admin.php/admin/Index/index.html`
----
因为最终生成的网址携带有应用名，导致无法正常访问到`app\admin\controller\Index->profile()`