### PR TITLE
改进兼容性

### DIFF
--- a/src/Url.php
+++ b/src/Url.php
@@ -68,7 +68,7 @@ class Url extends UrlBuild
         return $url;
     }
 
-    public function build()
+    public function build(): string
     {
         // 解析URL
         $url     = $this->url;


### PR DESCRIPTION
Declaration of think\app\Url::build() must be compatible with think\route\Url::build(): string