### PR TITLE
修正自动多应用识别 对闭包映射应用文件加载

### DIFF
--- a/src/MultiApp.php
+++ b/src/MultiApp.php
@@ -132,6 +132,7 @@ class MultiApp
                 if (isset($map[$name])) {
                     if ($map[$name] instanceof Closure) {
                         $result  = call_user_func_array($map[$name], [$this->app]);
+                        $this->path = $this->app->http->getPath();
                         $appName = $result ?: $name;
                     } else {
                         $appName = $map[$name];


### PR DESCRIPTION
```
    'app_map'          => [
        'test' => function ($app) {
            $app->http->path($app->getRootPath() . '/vendor/think-test-app/src/test');
            $app->config->set(['app_namespace' => 'think\\appMapTest'], 'app');
        },
    ],
```

或者可以的话在闭包回调的时候暴露出修改 `MultiApp::$path` 的方法