### PR TITLE
fix: 修复多语言在使用全局引入的 LoadLangPack 时无法自动检测的问题

### DIFF
--- a/src/MultiApp.php
+++ b/src/MultiApp.php
@@ -216,9 +216,6 @@ class MultiApp
         if (is_file($appPath . 'provider.php')) {
             $this->app->bind(include $appPath . 'provider.php');
         }
-
-        // 加载应用默认语言包
-        $this->app->loadLangPack($this->app->lang->defaultLangSet());
     }
 
 }


### PR DESCRIPTION
fixed #32

fixed https://github.com/top-think/framework/issues/2953

多应用中无需再次初始化默认语言 `App.php` 中已经初始化过。

https://github.com/top-think/framework/blob/05942a3c64639d8d2c4c2b44489ca27e65f690f6/src/think/App.php#L450-L455

再次初始化会导致全局引入的 LoadLangPack 中间件解析的语言被覆盖。

@liu21st 